### PR TITLE
Member Entity 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+*.properties
+!**/src/main/resources/application.properties
 
 ### NetBeans ###
 /nbproject/private/
@@ -35,3 +37,4 @@ out/
 
 ### VS Code ###
 .vscode/
+

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,25 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	//Querydsl 추가
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	sourceSets {
+		main {
+			java {
+				srcDirs = ["$projectDir/src/main/java", "$projectDir/build/generated"]
+			}
+		}
+	}
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+clean{
+	delete file('src/main/generated')
 }

--- a/sql/create_booking.sql
+++ b/sql/create_booking.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS `dingul_camping`.`booking` (
+  `id` BIGINT AUTO_INCREMENT,
+  `price` INT NOT NULL,
+  `start_date` DATE NOT NULL,
+  `end_date` DATE NOT NULL,
+  `people_number` INT NOT NULL,
+  `status` VARCHAR(20) NOT NULL,
+  `is_reviewed` TINYINT NOT NULL,
+  `room_id` BIGINT NOT NULL,
+  `member_id` BIGINT NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `booking_id_UNIQUE` (`id` ASC) VISIBLE,
+  INDEX `fk_booking_room1_idx` (`room_id` ASC) VISIBLE,
+  INDEX `fk_booking_member1_idx` (`member_id` ASC) VISIBLE,
+  CONSTRAINT `room_id`
+    FOREIGN KEY (`room_id`)
+    REFERENCES `dingul_camping`.`room` (`id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  CONSTRAINT `fk_booking_member`
+    FOREIGN KEY (`member_id`)
+    REFERENCES `dingul_camping`.`member` (`id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE)
+ENGINE = InnoDB

--- a/sql/create_member.sql
+++ b/sql/create_member.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS `dingul_camping`.`member` (
+  `id` BIGINT AUTO_INCREMENT PRIMARY KEY,
+  `name` VARCHAR(20) NOT NULL,
+  `password` VARCHAR(64) NOT NULL,
+  `email` VARCHAR(50) NULL,
+  `phone_number` VARCHAR(20) NULL,
+  `role` VARCHAR(10) NOT NULL,
+  `provider` VARCHAR(20) NULL,
+  `refresh_token` VARCHAR(64) NULL,
+  `created_date` DATETIME(6) NULL,
+  `last_modified_date` DATETIME(6) NULL,
+  UNIQUE INDEX `id_UNIQUE` (`id` ASC) VISIBLE)
+ENGINE = InnoDB

--- a/sql/create_process_date.sql
+++ b/sql/create_process_date.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS `dingul_camping`.`process_date` (
+  `id` BIGINT AUTO_INCREMENT,
+  `date` DATE NOT NULL,
+  `booking_id` BIGINT NOT NULL,
+  PRIMARY KEY (`id`, `booking_id`),
+  UNIQUE INDEX `idprocess_date_id_UNIQUE` (`id` ASC) VISIBLE,
+  INDEX `fk_process_date_booking1_idx` (`booking_id` ASC) VISIBLE,
+  CONSTRAINT `fk_process_date_booking1`
+    FOREIGN KEY (`booking_id`)
+    REFERENCES `dingul_camping`.`booking` (`id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE)
+ENGINE = InnoDB

--- a/sql/create_review.sql
+++ b/sql/create_review.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS `dingul_camping`.`review` (
+  `review_id` BIGINT AUTO_INCREMENT,
+  `title` VARCHAR(255) NULL,
+  `content` VARCHAR(10000) NULL,
+  `grade` DOUBLE NULL,
+  `room_id` BIGINT NOT NULL,
+  `booking_id` BIGINT NOT NULL,
+  `member_id` BIGINT NOT NULL,
+  PRIMARY KEY (`review_id`),
+  UNIQUE INDEX `review_id_UNIQUE` (`review_id` ASC) VISIBLE,
+  INDEX `fk_review_room1_idx` (`room_id` ASC) VISIBLE,
+  INDEX `fk_review_booking1_idx` (`booking_id` ASC) VISIBLE,
+  INDEX `fk_review_member1_idx` (`member_id` ASC) VISIBLE,
+  CONSTRAINT `fk_review_room1`
+    FOREIGN KEY (`room_id`)
+    REFERENCES `dingul_camping`.`room` (`id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  CONSTRAINT `fk_review_booking1`
+    FOREIGN KEY (`booking_id`)
+    REFERENCES `dingul_camping`.`booking` (`id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  CONSTRAINT `fk_review_member1`
+    FOREIGN KEY (`member_id`)
+    REFERENCES `dingul_camping`.`member` (`id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE)
+ENGINE = InnoDB

--- a/sql/create_room.sql
+++ b/sql/create_room.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS `dingul_camping`.`room` (
+  `id` BIGINT AUTO_INCREMENT,
+  `name` VARCHAR(15) NOT NULL,
+  `price` INT NOT NULL,
+  `content` VARCHAR(10000) NULL,
+  `img_src` VARCHAR(3000) NULL,
+  `room_type` VARCHAR(10) NULL,
+  `icon` VARCHAR(256) NULL,
+  `max_people` INT NULL,
+  `min_people` INT NULL,
+  `top` DOUBLE NULL,
+  `right` DOUBLE NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `room_id_UNIQUE` (`id` ASC) VISIBLE)
+ENGINE = InnoDB

--- a/src/main/java/dingulcamping/reservationapp/domain/member/entity/Member.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/entity/Member.java
@@ -1,0 +1,62 @@
+package dingulcamping.reservationapp.domain.member.entity;
+
+import dingulcamping.reservationapp.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+
+@Entity
+@Getter
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class Member extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy=GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique=true, nullable = false)
+    private String userId;
+    private String name;
+    private String password;
+    private String email;
+    private String phoneNumber;
+    private String role;
+    private String provider;
+    private String refreshToken;
+
+    //TODO
+//    @OneToMany(mappedBy="booking", fetch= FetchType.LAZY)
+//    private List<Booking> bookings=new ArrayList<>();
+
+    public Member(String userId, String name, String password, String email, String phoneNumber) {
+        this.userId=userId;
+        this.name = name;
+        this.password = password;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.role=String.valueOf(Role.USER);
+    }
+
+    public Member(String userId,String name, String password, String email, String phoneNumber, String role,
+                  String provider) {
+        this.userId=userId;
+        this.name = name;
+        this.password = password;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.role = role;
+        this.provider = provider;
+    }
+
+    public void changeRefreshToken(String refreshToken){
+        this.refreshToken=refreshToken;
+    }
+
+    public void changePassword(String password){
+        this.password=password;
+    }
+
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/member/entity/Role.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/entity/Role.java
@@ -1,0 +1,5 @@
+package dingulcamping.reservationapp.domain.member.entity;
+
+public enum Role {
+    ADMIN, USER
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/member/repository/MemberRepository.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/repository/MemberRepository.java
@@ -1,0 +1,20 @@
+package dingulcamping.reservationapp.domain.member.repository;
+
+import dingulcamping.reservationapp.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    List<Member> findAllByName(String name);
+    Optional<Member> findOneByUserId(String userId);
+    Optional<Member> findOneByNameAndEmail(String name, String email);
+    Optional<Member> findOneByRefreshToken(String refreshToken);
+    Optional<Member> findOneByProviderAndEmail(String provider, String email);
+    @Query("select m from Member m where m.provider='kakao' and m.email=:email")
+    Optional<Member> findKakaoUserByEmail(@Param("email") String email);
+    Optional<Member> deleteByUserId(String userId);
+}

--- a/src/main/java/dingulcamping/reservationapp/global/entity/BaseTimeEntity.java
+++ b/src/main/java/dingulcamping/reservationapp/global/entity/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package dingulcamping.reservationapp.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}

--- a/src/main/java/dingulcamping/reservationapp/global/entity/configuration/QuerydslConfig.java
+++ b/src/main/java/dingulcamping/reservationapp/global/entity/configuration/QuerydslConfig.java
@@ -1,0 +1,14 @@
+package dingulcamping.reservationapp.global.entity.configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager em){
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/test/java/dingulcamping/reservationapp/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/dingulcamping/reservationapp/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,72 @@
+package dingulcamping.reservationapp.domain.member.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dingulcamping.reservationapp.domain.member.entity.Member;
+import dingulcamping.reservationapp.domain.member.entity.QMember;
+import dingulcamping.reservationapp.domain.member.entity.Role;
+import jakarta.persistence.EntityManager;
+import org.aspectj.lang.annotation.Before;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static dingulcamping.reservationapp.domain.member.entity.Role.USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@Rollback(value = false)
+class MemberRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    EntityManager em;
+
+    @BeforeEach
+    public void before(){
+        Optional<Member> hb912 = memberRepository.findOneByUserId("hb912");
+        Optional<Member> hb915 = memberRepository.findOneByUserId("hb915");
+
+        if(hb912.isPresent()){
+            memberRepository.deleteByUserId(hb912.get().getUserId());
+            System.out.println("hb912 삭제");
+        }
+        if(hb915.isPresent()){
+            memberRepository.deleteByUserId(hb915.get().getUserId());
+            System.out.println("hb915 삭제");
+        }
+        em.flush();     //*주의 save의 우선순위가 더 높기 때문에 flush를 사용하지 않으면 delete가 반영되지 않는다.
+    }
+
+    /**
+     * test save, findById
+     */
+    @Test
+    @Rollback(value = false)
+    public void saveAndSelectById(){
+        Member memberA=new Member("hb912","memberA","12344456","ab@ab.com","010-5031-8478");
+        Member memberB=new Member("hb915","memberB","123444577","ab@abb.com","010-4444-8478");
+
+        memberRepository.save(memberA);
+        memberRepository.save(memberB);
+
+        Optional<Member> findMemberA = memberRepository.findOneByUserId(memberA.getUserId());
+        Optional<Member> findMemberB = memberRepository.findOneByUserId(memberB.getUserId());
+
+        assertThat(findMemberA.isPresent()).isTrue();
+        assertThat(findMemberA.get()).isEqualTo(memberA);
+        assertThat(findMemberB.isPresent()).isTrue();
+        assertThat(findMemberB.get()).isEqualTo(memberB);
+
+    }
+
+}

--- a/src/test/java/dingulcamping/reservationapp/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/dingulcamping/reservationapp/domain/member/repository/MemberRepositoryTest.java
@@ -69,4 +69,26 @@ class MemberRepositoryTest {
 
     }
 
+    @Test
+//    @Rollback(value = false)
+    public void findKakaoMemberByEmail(){
+        Member memberA=new Member("hb912","memberA","12344456","ab@ab.com","010-5031-8478", USER.toString(),"kakao");
+        Member memberB=new Member("hb915","memberB","123444577","ab@abb.com","010-4444-8478", USER.toString(),null);
+
+        memberRepository.save(memberA);
+        memberRepository.save(memberB);
+
+        Optional<Member> findMemberA = memberRepository.findKakaoUserByEmail(memberA.getEmail());
+        Optional<Member> findMemberB = memberRepository.findKakaoUserByEmail(memberB.getEmail());
+
+        assertThat(findMemberA.isPresent()).isTrue();
+        if(findMemberA.isPresent()) {
+            assertThat(findMemberA.get()).isEqualTo(memberA);
+        }
+        assertThat(findMemberB.isEmpty()).isTrue();
+        if(findMemberB.isPresent()) {
+            assertThat(findMemberB.get()).isEqualTo(memberB);
+        }
+    }
+
 }


### PR DESCRIPTION
## 🔗 Linked Issues
resolves #2 Member Entity 구현
<BR>

## 🔑 Key Changes

- Time Auditing Class 구현
- Member Entity Class 구현
- MemberRepository 구현
- Querydsl추가 및 config 설정(jpaQueryFactory 주입)

<br>

## 💬Comment
**TestCode 중 BeforeEach의 delete후 em.flush를 하는 이유?**
delete연산 후 save를 하는 경우 delete 연산보다 save의 우선순위가 높아서 delete 쿼리가 아닌 Insert 쿼리가 먼저 나갈 수 있다.
그렇게 되면 해당 row 가 삭제되지 않아 userId의 unique 옵션에 걸려 Exception이 발생한다. 꼭 em.flush를 해줄 것!
