### PR TITLE
회원 관련 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/dingulcamping/reservationapp/domain/mail/dto/MailDto.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/mail/dto/MailDto.java
@@ -1,0 +1,13 @@
+package dingulcamping.reservationapp.domain.mail.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MailDto {
+
+    private String to;
+    private String subject;
+    private String context;
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/mail/exception/FailMailException.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/mail/exception/FailMailException.java
@@ -1,0 +1,19 @@
+package dingulcamping.reservationapp.domain.mail.exception;
+
+public class FailMailException extends RuntimeException{
+    public FailMailException() {
+        super();
+    }
+
+    public FailMailException(String message) {
+        super(message);
+    }
+
+    public FailMailException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public FailMailException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/mail/service/MailService.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/mail/service/MailService.java
@@ -1,0 +1,48 @@
+package dingulcamping.reservationapp.domain.mail.service;
+
+import dingulcamping.reservationapp.domain.mail.dto.MailDto;
+import dingulcamping.reservationapp.domain.mail.exception.FailMailException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender javaMailSender;
+    private final SpringTemplateEngine templateEngine;
+    @Value("${front.server.address}")
+    private String serverAddress;
+
+    public void sendMail(MailDto mailDto, String redisKey){
+
+        MimeMessage mimeMessage=javaMailSender.createMimeMessage();
+
+        try{
+            Context context = new Context();
+            context.setVariable("redisKey",redisKey);
+            context.setVariable("server",serverAddress);
+            String mailText = templateEngine.process("mail", context);
+
+            MimeMessageHelper mimeMessageHelper=new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            mimeMessageHelper.setTo(mailDto.getTo());
+            mimeMessageHelper.setSubject(mailDto.getSubject());
+            mimeMessageHelper.setText(mailText, true);
+            javaMailSender.send(mimeMessage);
+
+            log.info("Success to send Mail");
+        }catch(MessagingException e){
+            log.error(e.getMessage());
+            throw new FailMailException("메일을 전송하는데 실패하였습니다.", e);
+        }
+    }
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/member/controller/MemberController.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/controller/MemberController.java
@@ -4,11 +4,15 @@ import dingulcamping.reservationapp.domain.member.dto.LoginDto;
 import dingulcamping.reservationapp.domain.member.dto.RegisterReqDto;
 import dingulcamping.reservationapp.domain.member.dto.TokenDto;
 import dingulcamping.reservationapp.domain.member.service.MemberService;
+import dingulcamping.reservationapp.global.security.JwtUtils;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +25,8 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
+    @Value("${jwt.secret}")
+    private String secretKey;
 
     @PostMapping("/register")
     public ResponseEntity<String> register(@Valid @RequestBody RegisterReqDto registerReqDto){
@@ -49,5 +55,14 @@ public class MemberController {
         response.addCookie(cookie);
         response.addHeader("authorization","");
         return ResponseEntity.ok("로그아웃이 완료되었습니다.");
+    }
+
+    @GetMapping("/confirmPW")
+    public ResponseEntity<Boolean> confirmPassword(@Valid String password, HttpServletRequest request){
+        final String authorization=request.getHeader(HttpHeaders.AUTHORIZATION);
+        String token=authorization.split(" ")[1];
+        Long memberId= JwtUtils.getMemberId(token,secretKey);
+        Boolean isPasswordCorrect=memberService.verifyPassword(memberId, password);
+        return ResponseEntity.ok(isPasswordCorrect);
     }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/member/controller/MemberController.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/controller/MemberController.java
@@ -110,11 +110,17 @@ public class MemberController {
         return ResponseEntity.ok("변경 성공");
     }
 
+    @DeleteMapping("/user")
+    public ResponseEntity<String> memberDelete(HttpServletRequest request){
+        Long memberId = getMemberId(request);
+        memberService.deleteMember(memberId);
+        return ResponseEntity.ok("탈퇴 성공");
+    }
+
     private Long getMemberId(HttpServletRequest request) {
         final String authorization= request.getHeader(HttpHeaders.AUTHORIZATION);
         String token=authorization.split(" ")[1];
         Long memberId= JwtUtils.getMemberId(token,secretKey);
         return memberId;
     }
-
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/member/controller/MemberController.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/controller/MemberController.java
@@ -89,4 +89,10 @@ public class MemberController {
         mailService.sendMail(mailDto,redisKey);
         return ResponseEntity.ok("메일 전송 완료");
     }
+
+    @GetMapping("/newPassword")
+    public ResponseEntity<MemberIdDto> certificateRedisKey(@Valid String redisKey){
+        ResetPwKey findRedisKey = resetPwKeyService.findRedisKey(redisKey);
+        return ResponseEntity.ok(new MemberIdDto(findRedisKey.getMemberId()));
+    }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/member/controller/MemberController.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/controller/MemberController.java
@@ -36,6 +36,7 @@ public class MemberController {
     @Value("${jwt.secret}")
     private String secretKey;
 
+
     @PostMapping("/register")
     public ResponseEntity<String> register(@Valid @RequestBody RegisterReqDto registerReqDto){
         log.info("회원가입 시작");
@@ -49,7 +50,7 @@ public class MemberController {
         log.info("accessToken={}",tokens.getAccessToken());
         String accessToken="Bearer "+tokens.getAccessToken();
         response.addHeader("authorization", accessToken);
-        if(!tokens.getRefreshToken().isEmpty()) {
+        if(tokens.getRefreshToken()!=null) {
             Cookie cookie = new Cookie("refreshToken", tokens.getRefreshToken());
             response.addCookie(cookie);
         }
@@ -94,5 +95,12 @@ public class MemberController {
     public ResponseEntity<MemberIdDto> certificateRedisKey(@Valid String redisKey){
         ResetPwKey findRedisKey = resetPwKeyService.findRedisKey(redisKey);
         return ResponseEntity.ok(new MemberIdDto(findRedisKey.getMemberId()));
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<String> changePassword(@Valid @RequestBody ChangePwDto changePwDto){
+        memberService.changePassword(changePwDto.getMemberId(),changePwDto.getPassword());
+        resetPwKeyService.deleteKey(changePwDto.getRedisKey());
+        return ResponseEntity.ok("패스워드 변경 완료");
     }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/member/controller/MemberController.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/controller/MemberController.java
@@ -68,9 +68,7 @@ public class MemberController {
 
     @GetMapping("/confirmPW")
     public ResponseEntity<Boolean> confirmPassword(@Valid String password, HttpServletRequest request){
-        final String authorization=request.getHeader(HttpHeaders.AUTHORIZATION);
-        String token=authorization.split(" ")[1];
-        Long memberId= JwtUtils.getMemberId(token,secretKey);
+        Long memberId = getMemberId(request);
         Boolean isPasswordCorrect=memberService.verifyPassword(memberId, password);
         return ResponseEntity.ok(isPasswordCorrect);
     }
@@ -103,4 +101,20 @@ public class MemberController {
         resetPwKeyService.deleteKey(changePwDto.getRedisKey());
         return ResponseEntity.ok("패스워드 변경 완료");
     }
+
+    @PatchMapping("/user")
+    public ResponseEntity<String> memberUpdate(@Valid @RequestBody MemberUpdateDto memberUpdateDto,
+                                               HttpServletRequest request){
+        Long memberId=getMemberId(request);
+        memberService.updateMember(memberId, memberUpdateDto);
+        return ResponseEntity.ok("변경 성공");
+    }
+
+    private Long getMemberId(HttpServletRequest request) {
+        final String authorization= request.getHeader(HttpHeaders.AUTHORIZATION);
+        String token=authorization.split(" ")[1];
+        Long memberId= JwtUtils.getMemberId(token,secretKey);
+        return memberId;
+    }
+
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/member/dto/ChangePwDto.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/dto/ChangePwDto.java
@@ -1,0 +1,18 @@
+package dingulcamping.reservationapp.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@Setter
+public class ChangePwDto {
+
+    private Long memberId;
+    private String redisKey;
+
+    @NotBlank(message="비밀번호를 입력해주세요.")
+    @Length(min=2,max=20,message="비밀번호는 최소 8자, 최대 20자로 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/member/dto/FindPwReq.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/dto/FindPwReq.java
@@ -1,0 +1,22 @@
+package dingulcamping.reservationapp.domain.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class FindPwReq {
+
+    @NotBlank(message="이메일 주소를 입력해주세요")
+    @Email(message="이메일 형식으로 입력해주세요.")
+    @Length(max=40,message="최대 40자까지 입력 가능합니다.")
+    private String email;
+
+    @NotBlank(message="이름을 입력해주세요")
+    @Length(min=2,max=10,message="이름은 최소 2자, 최대 10자로 입력해주세요")
+    private String name;
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/member/dto/MemberIdDto.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/dto/MemberIdDto.java
@@ -1,0 +1,13 @@
+package dingulcamping.reservationapp.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class MemberIdDto {
+
+    private Long memberId;
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/member/dto/MemberUpdateDto.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/dto/MemberUpdateDto.java
@@ -1,26 +1,17 @@
 package dingulcamping.reservationapp.domain.member.dto;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import lombok.*;
+import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 
-@Getter
 @Setter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-public class RegisterReqDto {
+@Getter
+public class MemberUpdateDto {
 
-    @NotBlank(message="이메일 주소를 입력해주세요")
-    @Email(message="이메일 형식으로 입력해주세요.")
-    @Length(max=40,message="최대 40자까지 입력 가능합니다.")
-    private String email;
-
-    @NotBlank(message="비밀번호를 입력해주세요.")
     @Length(min=8,max=20,message="비밀번호는 최소 8자, 최대 20자로 입력해주세요.")
     private String password;
 
-    @NotBlank(message="이름을 입력해주세요")
     @Length(min=2,max=10,message="이름은 최소 2자, 최대 10자로 입력해주세요")
     private String name;
 

--- a/src/main/java/dingulcamping/reservationapp/domain/member/entity/Member.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/entity/Member.java
@@ -2,12 +2,12 @@ package dingulcamping.reservationapp.domain.member.entity;
 
 import dingulcamping.reservationapp.domain.booking.entity.Booking;
 import dingulcamping.reservationapp.domain.member.dto.RegisterReqDto;
+import dingulcamping.reservationapp.domain.member.dto.MemberUpdateDto;
 import dingulcamping.reservationapp.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -68,6 +68,15 @@ public class Member extends BaseTimeEntity {
 
     public void setEncryptedPassword(String encryptedPassword){
         this.password=encryptedPassword;
+    }
+
+    public void updateMember(MemberUpdateDto memberUpdateDto){
+        if(memberUpdateDto.getName()!=null){
+            this.name= memberUpdateDto.getName();
+        }
+        if(memberUpdateDto.getPhoneNumber()!=null){
+            this.phoneNumber= memberUpdateDto.getPhoneNumber();
+        }
     }
 
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/member/entity/Member.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/entity/Member.java
@@ -32,7 +32,6 @@ public class Member extends BaseTimeEntity {
     @Enumerated(value=EnumType.STRING)
     private Role role;
     private String provider;
-    private String refreshToken;
 
     @OneToMany(mappedBy="member", fetch= FetchType.LAZY)
     private List<Booking> bookings=new ArrayList<>();
@@ -61,14 +60,6 @@ public class Member extends BaseTimeEntity {
         this.phoneNumber=registerReq.getPhoneNumber();
         this.role= USER;
         this.provider=null;
-    }
-
-    public void changeRefreshToken(String refreshToken){
-        this.refreshToken=refreshToken;
-    }
-
-    public void changePassword(String password){
-        this.password=password;
     }
 
     public void setProvider(String provider){

--- a/src/main/java/dingulcamping/reservationapp/domain/member/entity/ResetPwKey.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/entity/ResetPwKey.java
@@ -1,0 +1,23 @@
+package dingulcamping.reservationapp.domain.member.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@RedisHash(value="reset_pw_key",timeToLive=48*60*1000l)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ResetPwKey {
+
+    @Id
+    private String redisKey;
+    private Long memberId;
+
+    public ResetPwKey(String redisKey, Long memberId) {
+        this.redisKey = redisKey;
+        this.memberId = memberId;
+    }
+
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/member/exception/NameIsNotCorrectException.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/exception/NameIsNotCorrectException.java
@@ -1,0 +1,19 @@
+package dingulcamping.reservationapp.domain.member.exception;
+
+public class NameIsNotCorrectException extends RuntimeException {
+    public NameIsNotCorrectException() {
+        super();
+    }
+
+    public NameIsNotCorrectException(String message) {
+        super(message);
+    }
+
+    public NameIsNotCorrectException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NameIsNotCorrectException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/member/exception/RedisKeyExpiredException.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/exception/RedisKeyExpiredException.java
@@ -1,0 +1,19 @@
+package dingulcamping.reservationapp.domain.member.exception;
+
+public class RedisKeyExpiredException extends RuntimeException {
+    public RedisKeyExpiredException() {
+        super();
+    }
+
+    public RedisKeyExpiredException(String message) {
+        super(message);
+    }
+
+    public RedisKeyExpiredException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RedisKeyExpiredException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/member/exception/RedisPwKeySaveException.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/exception/RedisPwKeySaveException.java
@@ -1,0 +1,19 @@
+package dingulcamping.reservationapp.domain.member.exception;
+
+public class RedisPwKeySaveException extends RuntimeException {
+    public RedisPwKeySaveException() {
+        super();
+    }
+
+    public RedisPwKeySaveException(String message) {
+        super(message);
+    }
+
+    public RedisPwKeySaveException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RedisPwKeySaveException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/member/repository/MemberRepository.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/repository/MemberRepository.java
@@ -12,7 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findAllByName(String name);
     Optional<Member> findOneByNameAndEmail(String name, String email);
     Optional<Member> findOneByEmail(String email);
-    Optional<Member> findOneByRefreshToken(String refreshToken);
     Optional<Member> findOneByProviderAndEmail(String provider, String email);
     @Query("select m from Member m where m.provider='kakao' and m.email=:email")
     Optional<Member> findKakaoUserByEmail(@Param("email") String email);

--- a/src/main/java/dingulcamping/reservationapp/domain/member/repository/ResetPwKeyRepository.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/repository/ResetPwKeyRepository.java
@@ -1,6 +1,5 @@
 package dingulcamping.reservationapp.domain.member.repository;
 
-import dingulcamping.reservationapp.domain.member.entity.RefreshToken;
 import dingulcamping.reservationapp.domain.member.entity.ResetPwKey;
 import org.springframework.data.repository.CrudRepository;
 

--- a/src/main/java/dingulcamping/reservationapp/domain/member/repository/ResetPwKeyRepository.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/repository/ResetPwKeyRepository.java
@@ -1,0 +1,8 @@
+package dingulcamping.reservationapp.domain.member.repository;
+
+import dingulcamping.reservationapp.domain.member.entity.RefreshToken;
+import dingulcamping.reservationapp.domain.member.entity.ResetPwKey;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ResetPwKeyRepository extends CrudRepository<ResetPwKey, String> {
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/member/service/MemberService.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/service/MemberService.java
@@ -2,10 +2,10 @@ package dingulcamping.reservationapp.domain.member.service;
 
 import dingulcamping.reservationapp.domain.member.dto.LoginDto;
 import dingulcamping.reservationapp.domain.member.dto.RegisterReqDto;
+import dingulcamping.reservationapp.domain.member.dto.MemberUpdateDto;
 import dingulcamping.reservationapp.domain.member.dto.TokenDto;
 import dingulcamping.reservationapp.domain.member.entity.Member;
 import dingulcamping.reservationapp.domain.member.entity.RefreshToken;
-import dingulcamping.reservationapp.domain.member.entity.ResetPwKey;
 import dingulcamping.reservationapp.domain.member.entity.Role;
 import dingulcamping.reservationapp.domain.member.exception.*;
 import dingulcamping.reservationapp.domain.member.repository.MemberRepository;
@@ -104,8 +104,6 @@ public class MemberService {
         return findMember.get();
     }
 
-
-
     @Transactional(readOnly = false)
     public void changePassword(Long memberId, String password) {
         Optional<Member> findMember = memberRepository.findById(memberId);
@@ -113,5 +111,18 @@ public class MemberService {
             throw new MemberIsNotExistException("멤버 정보가 존재하지 않습니다.");
         }
         setNewPassword(password,findMember.get());
+    }
+
+    @Transactional(readOnly = false)
+    public void updateMember(Long memberId, MemberUpdateDto memberUpdateDto) {
+        Optional<Member> findMember = memberRepository.findById(memberId);
+        if(findMember.isEmpty()){
+            throw new MemberIsNotExistException("유저 정보를 불러오는데 실패했습니다.");
+        }
+        Member member = findMember.get();
+        if(memberUpdateDto.getPassword()!=null){
+            setNewPassword(memberUpdateDto.getPassword(),member);
+        }
+        member.updateMember(memberUpdateDto);
     }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/member/service/MemberService.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/service/MemberService.java
@@ -90,4 +90,9 @@ public class MemberService {
     }
 
 
+    public Boolean verifyPassword(Long memberId, String password) {
+        Optional<Member> findMember = memberRepository.findById(memberId);
+        Member member = findMember.get();
+        return bCryptPasswordEncoder.matches(password, member.getPassword());
+    }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/member/service/MemberService.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/service/MemberService.java
@@ -7,10 +7,7 @@ import dingulcamping.reservationapp.domain.member.entity.Member;
 import dingulcamping.reservationapp.domain.member.entity.RefreshToken;
 import dingulcamping.reservationapp.domain.member.entity.ResetPwKey;
 import dingulcamping.reservationapp.domain.member.entity.Role;
-import dingulcamping.reservationapp.domain.member.exception.EmailAlreadyExistException;
-import dingulcamping.reservationapp.domain.member.exception.MemberIsNotExistException;
-import dingulcamping.reservationapp.domain.member.exception.PasswordNotMatchException;
-import dingulcamping.reservationapp.domain.member.exception.RedisPwKeySaveException;
+import dingulcamping.reservationapp.domain.member.exception.*;
 import dingulcamping.reservationapp.domain.member.repository.MemberRepository;
 import dingulcamping.reservationapp.domain.member.repository.RefreshTokenRepository;
 import dingulcamping.reservationapp.domain.member.repository.ResetPwKeyRepository;
@@ -45,12 +42,12 @@ public class MemberService {
             throw new EmailAlreadyExistException("이 이메일은 현재 사용중입니다. 다른 이메일을 입력해 주세요.");
         }
 
-        String encryptedPassword = bCryptPasswordEncoder.encode(registerReqDto.getPassword());
         Member member=new Member(registerReqDto);
-        member.setEncryptedPassword(encryptedPassword);
+        setNewPassword(registerReqDto.getPassword(), member);
         memberRepository.save(member);
         log.info("회원가입완료");
     }
+
 
     public TokenDto login(LoginDto loginDto){
         String email=loginDto.getEmail();
@@ -88,6 +85,10 @@ public class MemberService {
         return JwtUtils.createJwt(memberId,role,secretKey,refreshExp);
     }
 
+    private void setNewPassword(String password, Member member) {
+        String encryptedPassword = bCryptPasswordEncoder.encode(password);
+        member.setEncryptedPassword(encryptedPassword);
+    }
 
     public Boolean verifyPassword(Long memberId, String password) {
         Optional<Member> findMember = memberRepository.findById(memberId);
@@ -103,11 +104,14 @@ public class MemberService {
         return findMember.get();
     }
 
-    public void saveRedisKey(ResetPwKey resetPwKey){
-        try {
-            resetPwKeyRepository.save(resetPwKey);
-        }catch(Exception e){
-            throw new RedisPwKeySaveException("redis 저장에 실패했습니다.");
+
+
+    @Transactional(readOnly = false)
+    public void changePassword(Long memberId, String password) {
+        Optional<Member> findMember = memberRepository.findById(memberId);
+        if(findMember.isEmpty()){
+            throw new MemberIsNotExistException("멤버 정보가 존재하지 않습니다.");
         }
+        setNewPassword(password,findMember.get());
     }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/member/service/MemberService.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/service/MemberService.java
@@ -125,4 +125,9 @@ public class MemberService {
         }
         member.updateMember(memberUpdateDto);
     }
+
+    @Transactional(readOnly = false)
+    public void deleteMember(Long memberId){
+        memberRepository.deleteById(memberId);
+    }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/member/service/ResetPwKeyService.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/service/ResetPwKeyService.java
@@ -1,0 +1,28 @@
+package dingulcamping.reservationapp.domain.member.service;
+
+import dingulcamping.reservationapp.domain.member.entity.ResetPwKey;
+import dingulcamping.reservationapp.domain.member.exception.RedisKeyExpiredException;
+import dingulcamping.reservationapp.domain.member.exception.RedisPwKeySaveException;
+import dingulcamping.reservationapp.domain.member.repository.ResetPwKeyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ResetPwKeyService {
+
+    private final ResetPwKeyRepository resetPwKeyRepository;
+
+    @Transactional
+    public void saveRedisKey(ResetPwKey resetPwKey){
+        try {
+            resetPwKeyRepository.save(resetPwKey);
+        }catch(Exception e){
+            throw new RedisPwKeySaveException("redis 저장에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/member/service/ResetPwKeyService.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/service/ResetPwKeyService.java
@@ -25,4 +25,12 @@ public class ResetPwKeyService {
             throw new RedisPwKeySaveException("redis 저장에 실패했습니다.");
         }
     }
+
+    public ResetPwKey findRedisKey(String redisKey){
+        Optional<ResetPwKey> findByRedisKey = resetPwKeyRepository.findById(redisKey);
+        if(findByRedisKey.isEmpty()){
+            throw new RedisKeyExpiredException("유효기간이 지난 링크입니다.");
+        }
+        return findByRedisKey.get();
+    }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/member/service/ResetPwKeyService.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/service/ResetPwKeyService.java
@@ -33,4 +33,9 @@ public class ResetPwKeyService {
         }
         return findByRedisKey.get();
     }
+
+    @Transactional
+    public void deleteKey(String redisKey) {
+        resetPwKeyRepository.deleteById(redisKey);
+    }
 }

--- a/src/main/java/dingulcamping/reservationapp/global/config/WebConfig.java
+++ b/src/main/java/dingulcamping/reservationapp/global/config/WebConfig.java
@@ -1,0 +1,22 @@
+package dingulcamping.reservationapp.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${front.server.address}")
+    private String frontServer;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowCredentials(true)
+                .allowedMethods("GET","POST","PATCH","DELETE")
+                .allowedOrigins(frontServer);
+    }
+}

--- a/src/main/java/dingulcamping/reservationapp/global/config/WebSecurityConfig.java
+++ b/src/main/java/dingulcamping/reservationapp/global/config/WebSecurityConfig.java
@@ -38,7 +38,9 @@ public class WebSecurityConfig{
         return http
                 .authorizeHttpRequests((authz)-> authz
                         .requestMatchers("/api/login").permitAll()
+                        .requestMatchers("/api/newPassword").permitAll()
                         .requestMatchers(HttpMethod.POST,"/api/register").permitAll()
+                        .requestMatchers(HttpMethod.PATCH,"/api/password").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/**").authenticated()
                         .requestMatchers("/**").permitAll())

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,4 @@ spring.config.import=application-security.properties
 #room table의 right컬럼이 sql 예약어라 오류(모든 예약어에 대해 따옴표를 추가함)
 jpa.properties.hibernate.auto_quote_keyword=true
 hibernate.globally_quoted_identifiers=true
+front.server.address=http://localhost:3000

--- a/src/main/resources/templates/mail.html
+++ b/src/main/resources/templates/mail.html
@@ -57,7 +57,7 @@
         <br/>
         <br/>
         <br/>
-        <a th:href="@{localhost:8080/api/newPassword(redisKey=${redisKey})}"
+        <a th:href="@{|${server}/newPassword?redisKey=${redisKey}|}"
            style="width: 179px;
             height: 60px;
             margin-left: 230px;

--- a/src/main/resources/templates/mail.html
+++ b/src/main/resources/templates/mail.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<meta charset="utf-8">
+<body>
+<main>
+    <div style="box-sizing: border-box; margin: auto; width: 640px; height: 901px">
+        <div style="width: 639px;
+                    height: 313px;
+                    left: 1px;
+                    top: 0px;
+                    background: rgba(82, 79, 161, 0.3);">
+            <div style="width: 273px;
+              height: 26px;
+              padding-left: 183px;
+              padding-top: 118px;
+              font-family: 'Noto Sans KR';
+              font-style: normal;
+              font-weight: 700;
+              font-size: 15px;
+              line-height: 22px;
+              text-align: center;">
+                <span style="color: #524fa1">딍굴딍굴</span>을 다시 찾아주셔서 감사합니다
+            </div>
+            <div style="width: 273px;
+              height: 72px;
+              padding-left: 183px;
+              font-family: 'Noto Sans KR';
+              font-style: normal;
+              font-weight: 700;
+              font-size: 40px;
+              line-height: 58px;
+              text-align: center;
+              color: #000000;">
+                비밀번호 변경
+            </div>
+        </div>
+        <div style="width: 494px;
+            height: 35px;
+            padding-left: 82px;
+            padding-top: 20px;
+            font-family: 'Noto Sans KR';
+            color: #000000;">
+            <h2>안녕하세요, 고객님</h2>
+        </div>
+        <div style="width: 494px;
+            height: 60px;
+            padding-left: 82px;
+            padding-top: 50px;
+            font-family: 'Noto Sans KR';
+            font-style: bold;
+            font-weight: 500;
+            font-size: 17px;
+            line-height: 26px;
+            color: #000000;">
+            아래의 버튼을 클릭하시면 비밀번호를 변경할 수 있는 페이지로 이동합니다.
+        </div>
+        <br/>
+        <br/>
+        <br/>
+        <a th:href="@{localhost:8080/api/newPassword(redisKey=${redisKey})}"
+           style="width: 179px;
+            height: 60px;
+            margin-left: 230px;
+            padding: 15px 25px;
+            text-align: center;
+            text-decoration: none;
+            font-style: normal;
+            font-weight: 700;
+            font-size: 16px;
+            line-height: 23px;
+            background: #524fa1;
+            color: #ffffff;
+            border-radius: 20px;">비밀번호변경</a>
+        <div style="width: 532px;
+            height: 30px;
+            padding-left: 54px;
+            padding-top: 90px;
+            padding-bottom: 100px;
+            font-family: 'sans-serif';
+            font-style: bold;
+            font-weight: 900;
+            font-size: 17px;
+            line-height: 26px;
+            text-align: center;
+            color: rgba(0, 0, 0, 0.7);">
+            위의 링크는 메일이 발송한 시점부터 <span style="color: #524fa1">48시간</span>만 유효 합니다.
+        </div>
+        <footer style="
+            width: 640px;
+            height: 92px;
+            padding-left: 10px;
+            padding-top: 20px;
+            border-top: 2px solid #d1d1d1;
+          ">
+            <div>
+                <img style="width: 80px; height: 80px; float: left"
+                     src="https://i.imgur.com/TQfwNmH.png?1"
+                     alt="logo"/>
+                <div style="
+                width: 500px;
+                height: 23px;
+                margin-left: 107px;
+                top: 18px;
+                font-family: 'Noto Sans KR';
+                font-style: normal;
+                font-weight: 400;
+                font-size: 12px;
+                line-height: 17px;
+                color: #959595;
+              ">
+                    캠핑장 주소 : 52234 경상남도 산청군 시천면 남명로 376
+                </div>
+                <div style="
+                width: 500px;
+                height: 26px;
+                margin-left: 107px;
+                top: 30px;
+                font-family: 'Noto Sans KR';
+                font-style: normal;
+                font-weight: 400;
+                font-size: 12px;
+                line-height: 17px;
+                display: flex;
+                align-items: center;
+                color: #959595;
+              ">
+                    사업자등록번호 : 654-88-45613 대표전화 : 010-4567-3210
+                </div>
+                <div style="
+                width: 500px;
+                height: 26px;
+                margin-left: 107px;
+                top: 50px;
+                font-family: 'Noto Sans KR';
+                font-style: normal;
+                font-weight: 400;
+                font-size: 12px;
+                line-height: 17px;
+                display: flex;
+                align-items: center;
+                color: #959595;
+              ">
+                    Copyright © Korea National Park Service. All Rights Reserved.
+                </div>
+            </div>
+        </footer>
+    </div>
+</main>
+</body>

--- a/src/test/java/dingulcamping/reservationapp/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/dingulcamping/reservationapp/domain/member/repository/MemberRepositoryTest.java
@@ -90,4 +90,21 @@ class MemberRepositoryTest {
         }
     }
 
+    @Test
+    public void deleteByNameAndEmail(){
+        //given
+        String name1 = "memberA";
+        String email1 = "ab@ab.com";
+        String email2 = "ab@abb.com";
+        //when
+        memberRepository.deleteByNameAndEmail(name1,email1);
+        //then
+        Optional<Member> findByEmail = memberRepository.findOneByEmail(email1);
+        Optional<Member> findByEmail2 = memberRepository.findOneByEmail(email2);
+
+        assertThat(findByEmail.isEmpty()).isTrue();
+        assertThat(findByEmail2.isEmpty()).isFalse();
+
+    }
+
 }

--- a/src/test/java/dingulcamping/reservationapp/domain/member/repository/ResetPwKeyRepositoryTest.java
+++ b/src/test/java/dingulcamping/reservationapp/domain/member/repository/ResetPwKeyRepositoryTest.java
@@ -1,0 +1,44 @@
+package dingulcamping.reservationapp.domain.member.repository;
+
+import dingulcamping.reservationapp.domain.member.entity.ResetPwKey;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class ResetPwKeyRepositoryTest {
+
+    @Autowired
+    ResetPwKeyRepository resetPwKeyRepository;
+
+    @Test
+    public void deleteKeys(){
+        //given
+        Long memberId=60L;
+        String randomkey1 = UUID.randomUUID().toString();
+        String randomkey2 = UUID.randomUUID().toString();
+        String randomkey3 = UUID.randomUUID().toString();
+        resetPwKeyRepository.save(new ResetPwKey(randomkey1,memberId));
+        resetPwKeyRepository.save(new ResetPwKey(randomkey2,memberId));
+        resetPwKeyRepository.save(new ResetPwKey(randomkey3,memberId));
+
+        //when
+        resetPwKeyRepository.deleteById(randomkey1);
+
+        //then
+        Optional<ResetPwKey> findById1 = resetPwKeyRepository.findById(randomkey1);
+        Optional<ResetPwKey> findById2 = resetPwKeyRepository.findById(randomkey2);
+        Optional<ResetPwKey> findById3 = resetPwKeyRepository.findById(randomkey3);
+
+        assertThat(findById1.isEmpty()).isTrue();
+        assertThat(findById2.isEmpty()).isFalse();
+        assertThat(findById3.isEmpty()).isFalse();
+    }
+}


### PR DESCRIPTION
## 🔗 Linked Issues
resolves #13   로그인 API 구현
<BR>

## 🔑 Key Changes

- 회원 정보 수정 API 구현
- 패스워드 찾기/변경 API 구현
- 회원 탈퇴 API 구현
- mail service 로직 구현 (redisKey 발급)

<br>

## 💬Comment
 **작년 이후로 gmail의 보안정책이 바뀌었다** 
less secure app access가 더이상 이용할 수 없고 2단계 인증과 앱 비밀번호를 통해 메일을 보낼 수 있다.
자세한 내용은 다음의 링크를 참조할 것 (https://velog.io/@tjddus0302/Spring-Boot-%EB%A9%94%EC%9D%BC-%EB%B0%9C%EC%86%A1-%EA%B8%B0%EB%8A%A5-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0-Gmail)

**cors 허용 방법**
front server 주소와 backend server 주소가 달라 cors 허용을 따로 풀어주어야 한다. 필자는 Cookie도 사용하므로(withCredential 옵션) Credentials도 허용해주어야 한다. (WebConfig 부분을 참조 할 것, cors 허용 코드 작성 commit)