### PR TITLE
review API 구현

### DIFF
--- a/src/main/java/dingulcamping/reservationapp/domain/booking/controller/BookingController.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/booking/controller/BookingController.java
@@ -1,11 +1,8 @@
 package dingulcamping.reservationapp.domain.booking.controller;
 
-import dingulcamping.reservationapp.domain.booking.dto.BookingCreateDto;
-import dingulcamping.reservationapp.domain.booking.dto.SearchByDateDto;
+import dingulcamping.reservationapp.domain.booking.dto.*;
 import dingulcamping.reservationapp.domain.booking.entity.BookingStatus;
 import dingulcamping.reservationapp.domain.room.dto.SimpleRoomDto;
-import dingulcamping.reservationapp.domain.booking.dto.PageBookingInfoDto;
-import dingulcamping.reservationapp.domain.booking.dto.SearchRoomByDateDto;
 import dingulcamping.reservationapp.domain.booking.service.BookingService;
 import dingulcamping.reservationapp.domain.member.entity.Member;
 import dingulcamping.reservationapp.global.security.AuthUtils;
@@ -14,6 +11,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -39,7 +38,7 @@ public class BookingController {
                                                 HttpServletRequest request){
         Member member = authUtils.getMember();
         bookingService.createBooking(bookingCreateDto,member);
-        return ResponseEntity.ok("생성완료");
+        return new ResponseEntity<>("생성 완료", HttpStatus.CREATED);
     }
 
     @GetMapping("/user")
@@ -63,7 +62,7 @@ public class BookingController {
     }
 
     @GetMapping("/confirm")
-    public ResponseEntity<String> confirmBooking(@RequestBody SearchByDateDto searchByDateDto){
+    public ResponseEntity<String> confirmBooking(@ModelAttribute SearchByDateDto searchByDateDto){
         bookingService.confirmBooking(searchByDateDto);
         return ResponseEntity.ok("확인 완료");
     }
@@ -75,7 +74,7 @@ public class BookingController {
     }
 
     @PatchMapping("/review")
-    public ResponseEntity<String> addReview(@RequestBody Long bookingID){
+    public ResponseEntity<String> addReview(@RequestBody BookingIdDto bookingID){
         return ResponseEntity.ok("리뷰 작성 완료");
     }
 

--- a/src/main/java/dingulcamping/reservationapp/domain/booking/dto/BookingCreateDto.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/booking/dto/BookingCreateDto.java
@@ -18,8 +18,7 @@ import java.util.List;
 
 @Getter
 @Setter
-@AllArgsConstructor
-@NoArgsConstructor
+
 public class BookingCreateDto {
 
     @NotNull
@@ -38,5 +37,5 @@ public class BookingCreateDto {
     private String requirements;
 
     @NotNull
-    private Long roomId;
+    private Long roomID;
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/booking/dto/BookingIdDto.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/booking/dto/BookingIdDto.java
@@ -1,0 +1,14 @@
+package dingulcamping.reservationapp.domain.booking.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BookingIdDto {
+    private Long bookingID;
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/booking/dto/CheckPassed.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/booking/dto/CheckPassed.java
@@ -1,0 +1,12 @@
+package dingulcamping.reservationapp.domain.booking.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class CheckPassed {
+    private Boolean isPassed;
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/booking/dto/PageBookingInfoDto.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/booking/dto/PageBookingInfoDto.java
@@ -9,13 +9,14 @@ import java.util.stream.Stream;
 @Getter
 public class PageBookingInfoDto {
     private List<BookingInfoDto> bookingInfos;
-    private List<Boolean> checkPassed;
+    private List<CheckPassed> checkPassed;
     private int totalPage;
 
     public PageBookingInfoDto(List<BookingInfoDto> bookingInfos, int totalPage) {
         this.bookingInfos = bookingInfos;
         Date today = new Date(System.currentTimeMillis());
-        this.checkPassed = bookingInfos.stream().map(booking -> booking.getEndDate().before(today)).toList();
+        this.checkPassed =
+                bookingInfos.stream().map(booking -> new CheckPassed(booking.getEndDate().before(today))).toList();
         this.totalPage = totalPage;
     }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/booking/dto/SearchByDateDto.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/booking/dto/SearchByDateDto.java
@@ -4,20 +4,54 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import java.util.Date;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.sql.Date;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Slf4j
 public class SearchByDateDto {
-    @DateTimeFormat(pattern = "yyyy-MM-dd")
-    private Date startDate;
 
-    @DateTimeFormat(pattern="yyyy-MM-dd")
-    private Date endDate;
-
+    private String startDate;
+    private String endDate;
     private Long roomID;
+
+    public Date convertStartDate(){
+        String replaceDate = this.startDate.replace("\"", "");
+        log.info("startDate={}",replaceDate);
+        return getDate(replaceDate);
+    }
+
+    public Date convertEndDate(){
+        String replaceDate = this.endDate.replace("\"", "");
+        log.info("endDate={}",replaceDate);
+
+        return getDate(replaceDate);
+    }
+
+    public Long getRoomID() {
+        return roomID;
+    }
+
+    private Date getDate(String replaceDate) {
+        SimpleDateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd");
+        try {
+            java.util.Date utilDate = isoFormat.parse(replaceDate);
+            long timeInMillis = utilDate.getTime();
+            Date sqlDate = new Date(timeInMillis);
+
+            System.out.println("ISO Date-Time String: " + replaceDate);
+            System.out.println("java.sql.Date: " + sqlDate);
+            return sqlDate;
+        } catch (ParseException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/booking/entity/Booking.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/booking/entity/Booking.java
@@ -74,6 +74,7 @@ public class Booking extends BaseTimeEntity {
         this.member = member;
         this.status=BookingStatus.BOOKING_REQ;
         this.review=null;
+        member.addBooking(this);
     }
 
     public void createReview(Review review) {

--- a/src/main/java/dingulcamping/reservationapp/domain/booking/repository/BookingRepositoryImpl.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/booking/repository/BookingRepositoryImpl.java
@@ -13,6 +13,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
 import java.sql.Date;
+import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -119,5 +121,18 @@ public class BookingRepositoryImpl implements BookingRepositoryCustom{
                 .selectFrom(booking)
                 .where(booking.status.eq(BOOKING_CONFIRM).and(booking.endDate.after(currentDate)))
                 .fetch();
+    }
+
+    private List<Date> getProcessDate(Date startDate, Date endDate) {
+        Date curDate= startDate;
+        List<Date> processDate=new ArrayList<>();
+        while(curDate.before(endDate)){
+            processDate.add(curDate);
+            Calendar calendar=Calendar.getInstance();
+            calendar.setTime(curDate);
+            calendar.add(Calendar.DAY_OF_MONTH, 1);
+            curDate=new Date(calendar.getTimeInMillis());
+        }
+        return processDate;
     }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/booking/service/BookingService.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/booking/service/BookingService.java
@@ -44,13 +44,13 @@ public class BookingService {
         checkDates(startDate,endDate);
 
         int peopleNumber = bookingCreateDto.getPeopleNumber();
-        Room room = roomRepository.findById(bookingCreateDto.getRoomId()).orElseThrow(NotExistRoomException::new);
+        Room room = roomRepository.findById(bookingCreateDto.getRoomID()).orElseThrow(NotExistRoomException::new);
         if(peopleNumber>room.getMaxPeople()||peopleNumber<room.getMinPeople()){
             throw new InvalidPeopleNumberException();
         }
 
         isBookingExist(getProcessDate(bookingCreateDto.getStartDate(),bookingCreateDto.getEndDate()),
-                bookingCreateDto.getRoomId());
+                bookingCreateDto.getRoomID());
         Booking booking = new Booking(bookingCreateDto,member,room);
         bookingRepository.save(booking);
     }
@@ -107,8 +107,8 @@ public class BookingService {
     }
 
     public void confirmBooking(SearchByDateDto searchByDateDto){
-        Date startDate = new Date(searchByDateDto.getStartDate().getTime());
-        Date endDate = new Date(searchByDateDto.getEndDate().getTime());
+        Date startDate = searchByDateDto.convertStartDate();
+        Date endDate = searchByDateDto.convertEndDate();
         List<Date> processDate = getProcessDate(startDate, endDate);
 
         checkDates(startDate,endDate);

--- a/src/main/java/dingulcamping/reservationapp/domain/booking/service/BookingService.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/booking/service/BookingService.java
@@ -49,8 +49,9 @@ public class BookingService {
             throw new InvalidPeopleNumberException();
         }
 
+        isBookingExist(getProcessDate(bookingCreateDto.getStartDate(),bookingCreateDto.getEndDate()),
+                bookingCreateDto.getRoomId());
         Booking booking = new Booking(bookingCreateDto,member,room);
-        isBookingExist(booking.getProcessDate(), bookingCreateDto.getRoomId());
         bookingRepository.save(booking);
     }
 

--- a/src/main/java/dingulcamping/reservationapp/domain/member/dto/SimpleMemberInfo.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/dto/SimpleMemberInfo.java
@@ -1,0 +1,12 @@
+package dingulcamping.reservationapp.domain.member.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SimpleMemberInfo {
+    private Long _id;
+    private String name;
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/member/entity/Member.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/entity/Member.java
@@ -79,4 +79,7 @@ public class Member extends BaseTimeEntity {
         }
     }
 
+    public void addBooking(Booking booking){
+        this.bookings.add(booking);
+    }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/member/entity/Role.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/member/entity/Role.java
@@ -1,5 +1,11 @@
 package dingulcamping.reservationapp.domain.member.entity;
 
+import dingulcamping.reservationapp.domain.room.entity.RoomType;
+
 public enum Role {
-    ADMIN, USER
+    ADMIN, USER;
+
+    public String toLowerCase() {
+        return name().toLowerCase();
+    }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/review/controller/ReviewController.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/controller/ReviewController.java
@@ -2,17 +2,19 @@ package dingulcamping.reservationapp.domain.review.controller;
 
 import dingulcamping.reservationapp.domain.member.entity.Member;
 import dingulcamping.reservationapp.domain.review.dto.ReviewCreateDto;
+import dingulcamping.reservationapp.domain.review.dto.ReviewInfoDto;
 import dingulcamping.reservationapp.domain.review.service.ReviewService;
 import dingulcamping.reservationapp.global.security.AuthUtils;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @Validated
@@ -25,10 +27,16 @@ public class ReviewController {
     private final AuthUtils authUtils;
 
     @PostMapping("/create")
-    public ResponseEntity<String> createReview(@Valid ReviewCreateDto reviewCreateDto){
+    public ResponseEntity<String> createReview(@Valid @RequestBody ReviewCreateDto reviewCreateDto){
         Member member = authUtils.getMember();
         reviewService.createReview(reviewCreateDto, member);
         return ResponseEntity.ok("리뷰작성이 완료되었습니다.");
     }
 
+    @GetMapping("")
+    public ResponseEntity<Page<ReviewInfoDto>> findByRoomId(Long roomID, Pageable pageable){
+        Page<ReviewInfoDto> results = reviewService.getRoomReviews(roomID, pageable);
+        log.info("result={}",results);
+        return ResponseEntity.ok(results);
+    }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/review/controller/ReviewController.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/controller/ReviewController.java
@@ -39,4 +39,11 @@ public class ReviewController {
         log.info("result={}",results);
         return ResponseEntity.ok(results);
     }
+
+    @GetMapping("/booking")
+    public ResponseEntity<ReviewInfoDto> findByBookingId(Long bookingID){
+        log.info("bookingid={}",bookingID);
+        ReviewInfoDto result=reviewService.getBookingReview(bookingID);
+        return ResponseEntity.ok(result);
+    }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/review/controller/ReviewController.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/controller/ReviewController.java
@@ -1,0 +1,34 @@
+package dingulcamping.reservationapp.domain.review.controller;
+
+import dingulcamping.reservationapp.domain.member.entity.Member;
+import dingulcamping.reservationapp.domain.review.dto.ReviewCreateDto;
+import dingulcamping.reservationapp.domain.review.service.ReviewService;
+import dingulcamping.reservationapp.global.security.AuthUtils;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/review")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+    private final AuthUtils authUtils;
+
+    @PostMapping("/create")
+    public ResponseEntity<String> createReview(@Valid ReviewCreateDto reviewCreateDto){
+        Member member = authUtils.getMember();
+        reviewService.createReview(reviewCreateDto, member);
+        return ResponseEntity.ok("리뷰작성이 완료되었습니다.");
+    }
+
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/review/controller/ReviewController.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/controller/ReviewController.java
@@ -46,4 +46,12 @@ public class ReviewController {
         ReviewInfoDto result=reviewService.getBookingReview(bookingID);
         return ResponseEntity.ok(result);
     }
+
+    @PatchMapping("/{reviewID}")
+    public ResponseEntity<String> updateReview(@PathVariable Long reviewID,
+                                               @RequestBody ReviewUpdateDto reviewUpdateDto){
+        reviewService.updateReview(reviewID,reviewUpdateDto);
+        log.info("content={}",reviewUpdateDto.getContent());
+        return ResponseEntity.ok("수정 완료");
+    }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/review/controller/ReviewController.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/controller/ReviewController.java
@@ -3,11 +3,13 @@ package dingulcamping.reservationapp.domain.review.controller;
 import dingulcamping.reservationapp.domain.member.entity.Member;
 import dingulcamping.reservationapp.domain.review.dto.ReviewCreateDto;
 import dingulcamping.reservationapp.domain.review.dto.ReviewInfoDto;
+import dingulcamping.reservationapp.domain.review.dto.ReviewUpdateDto;
 import dingulcamping.reservationapp.domain.review.service.ReviewService;
 import dingulcamping.reservationapp.global.security.AuthUtils;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.Response;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -53,5 +55,11 @@ public class ReviewController {
         reviewService.updateReview(reviewID,reviewUpdateDto);
         log.info("content={}",reviewUpdateDto.getContent());
         return ResponseEntity.ok("수정 완료");
+    }
+
+    @DeleteMapping("/{reviewID}")
+    public ResponseEntity<String> deleteReview(@PathVariable Long reviewID){
+        reviewService.deleteReview(reviewID);
+        return ResponseEntity.ok("삭제 완료");
     }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/review/dto/ReviewCreateDto.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/dto/ReviewCreateDto.java
@@ -1,0 +1,32 @@
+package dingulcamping.reservationapp.domain.review.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReviewCreateDto {
+
+    @NotNull
+    private Long roomID;
+
+    @NotNull
+    private Long bookingID;
+
+    @Length(max=10000,message="내용은 10000자 이내로 입력해주십시오.")
+    private String content;
+
+    @NotBlank(message="제목을 입력해 주십시오.")
+    @Length(max=100,message="제목은 100자 이내로 입력해 주십시오.")
+    private String title;
+
+    private Double grade;
+    private String name;
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/review/dto/ReviewInfoDto.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/dto/ReviewInfoDto.java
@@ -1,0 +1,31 @@
+package dingulcamping.reservationapp.domain.review.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import dingulcamping.reservationapp.domain.member.dto.SimpleMemberInfo;
+import dingulcamping.reservationapp.domain.room.dto.SimpleRoomDto;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReviewInfoDto {
+    private Long _id;
+    private SimpleRoomDto roomID;
+    private SimpleMemberInfo userID;
+    private Long bookingID;
+    private String title;
+    private String content;
+    private Double grade;
+
+    @QueryProjection
+    public ReviewInfoDto(Long _id, Long roomId, String roomName, Long memberId, String memberName, Long bookingId,
+                         String title, String content, Double grade) {
+        this._id = _id;
+        this.roomID=new SimpleRoomDto(roomId,roomName);
+        this.userID=new SimpleMemberInfo(memberId,memberName);
+        this.bookingID=bookingId;
+        this.title=title;
+        this.content=content;
+        this.grade=grade;
+    }
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/review/dto/ReviewUpdateDto.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/dto/ReviewUpdateDto.java
@@ -1,0 +1,23 @@
+package dingulcamping.reservationapp.domain.review.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReviewUpdateDto {
+    @Length(max=10000,message="내용은 10000자 이내로 입력해주십시오.")
+    private String content;
+
+    @NotBlank(message="제목을 입력해 주십시오.")
+    @Length(max=100,message="제목은 100자 이내로 입력해 주십시오.")
+    private String title;
+
+    private Double grade;
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/review/entity/Review.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/entity/Review.java
@@ -3,6 +3,7 @@ package dingulcamping.reservationapp.domain.review.entity;
 import dingulcamping.reservationapp.domain.booking.entity.Booking;
 import dingulcamping.reservationapp.domain.member.entity.Member;
 import dingulcamping.reservationapp.domain.review.dto.ReviewCreateDto;
+import dingulcamping.reservationapp.domain.review.dto.ReviewUpdateDto;
 import dingulcamping.reservationapp.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -35,5 +36,11 @@ public class Review extends BaseTimeEntity {
 
     public Review(ReviewCreateDto reviewCreateDto, Booking booking, Member member) {
         this(reviewCreateDto.getTitle(), reviewCreateDto.getContent(), reviewCreateDto.getGrade(), booking);
+    }
+
+    public void updateReview(ReviewUpdateDto reviewUpdateDto) {
+        this.title = reviewUpdateDto.getTitle();
+        this.content = reviewUpdateDto.getContent();
+        this.grade = reviewUpdateDto.getGrade();
     }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/review/entity/Review.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/entity/Review.java
@@ -19,13 +19,13 @@ public class Review extends BaseTimeEntity {
 
     private String title;
     private String content;
-    private double grade;
+    private Double grade;
 
     @OneToOne(fetch=FetchType.LAZY)
     @JoinColumn(name="booking_id")
     private Booking booking;
 
-    public Review(String title, String content, double grade, Booking booking) {
+    public Review(String title, String content, Double grade, Booking booking) {
         this.title = title;
         this.content = content;
         this.grade = grade;

--- a/src/main/java/dingulcamping/reservationapp/domain/review/entity/Review.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/entity/Review.java
@@ -1,6 +1,8 @@
 package dingulcamping.reservationapp.domain.review.entity;
 
 import dingulcamping.reservationapp.domain.booking.entity.Booking;
+import dingulcamping.reservationapp.domain.member.entity.Member;
+import dingulcamping.reservationapp.domain.review.dto.ReviewCreateDto;
 import dingulcamping.reservationapp.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -29,5 +31,9 @@ public class Review extends BaseTimeEntity {
         this.grade = grade;
         this.booking = booking;
         booking.createReview(this);
+    }
+
+    public Review(ReviewCreateDto reviewCreateDto, Booking booking, Member member) {
+        this(reviewCreateDto.getTitle(), reviewCreateDto.getContent(), reviewCreateDto.getGrade(), booking);
     }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/review/exception/InvalidMemberException.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/exception/InvalidMemberException.java
@@ -1,0 +1,10 @@
+package dingulcamping.reservationapp.domain.review.exception;
+
+import dingulcamping.reservationapp.global.exception.CustomException;
+import dingulcamping.reservationapp.global.exception.ErrorCode;
+
+public class InvalidMemberException extends CustomException {
+    public InvalidMemberException() {
+        super(ErrorCode.INVALID_MEMBER);
+    }
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/review/exception/NotExistReviewException.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/exception/NotExistReviewException.java
@@ -1,0 +1,10 @@
+package dingulcamping.reservationapp.domain.review.exception;
+
+import dingulcamping.reservationapp.global.exception.CustomException;
+import dingulcamping.reservationapp.global.exception.ErrorCode;
+
+public class NotExistReviewException extends CustomException {
+    public NotExistReviewException() {
+        super(ErrorCode.NOT_EXIST_REVIEW);
+    }
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/review/exception/ReviewIsExistException.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/exception/ReviewIsExistException.java
@@ -1,0 +1,11 @@
+package dingulcamping.reservationapp.domain.review.exception;
+
+import dingulcamping.reservationapp.global.exception.CustomException;
+import dingulcamping.reservationapp.global.exception.ErrorCode;
+
+public class ReviewIsExistException extends CustomException {
+    
+    public ReviewIsExistException(){
+        super(ErrorCode.REVIEW_IS_EXIST);
+    }
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/repository/ReviewRepository.java
@@ -9,5 +9,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review,Long>, ReviewRepositoryCustom {
-    Optional<Review> findByBooking(Booking booking);
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/repository/ReviewRepositoryCustom.java
@@ -1,5 +1,6 @@
 package dingulcamping.reservationapp.domain.review.repository;
 
+import dingulcamping.reservationapp.domain.review.dto.ReviewInfoDto;
 import dingulcamping.reservationapp.domain.review.entity.Review;
 import dingulcamping.reservationapp.domain.room.entity.Room;
 import org.springframework.data.domain.Page;
@@ -8,6 +9,6 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface ReviewRepositoryCustom {
-    Page<Review> findByRoomId(Long roomId, Pageable pageable);
+    Page<ReviewInfoDto> findByRoom(Room room, Pageable pageable);
     List<Review> findByMemberId(Long memberId);
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/repository/ReviewRepositoryCustom.java
@@ -1,5 +1,6 @@
 package dingulcamping.reservationapp.domain.review.repository;
 
+import dingulcamping.reservationapp.domain.booking.entity.Booking;
 import dingulcamping.reservationapp.domain.review.dto.ReviewInfoDto;
 import dingulcamping.reservationapp.domain.review.entity.Review;
 import dingulcamping.reservationapp.domain.room.entity.Room;
@@ -7,8 +8,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReviewRepositoryCustom {
     Page<ReviewInfoDto> findByRoom(Room room, Pageable pageable);
     List<Review> findByMemberId(Long memberId);
+    Optional<ReviewInfoDto> findByBooking(Booking booking);
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/repository/ReviewRepositoryImpl.java
@@ -2,6 +2,7 @@ package dingulcamping.reservationapp.domain.review.repository;
 
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import dingulcamping.reservationapp.domain.booking.entity.Booking;
 import dingulcamping.reservationapp.domain.review.dto.QReviewInfoDto;
 import dingulcamping.reservationapp.domain.review.dto.ReviewInfoDto;
 import dingulcamping.reservationapp.domain.review.entity.Review;
@@ -13,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
+import java.util.Optional;
 
 import static dingulcamping.reservationapp.domain.booking.entity.QBooking.booking;
 import static dingulcamping.reservationapp.domain.member.entity.QMember.member;
@@ -53,6 +55,30 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                 .where(room.id.eq(roomDto.getId()));
 
         return PageableExecutionUtils.getPage(reviews, pageable, () -> countQuery.fetchOne());
+    }
+
+    @Override
+    public Optional<ReviewInfoDto> findByBooking(Booking bookingDto) {
+        return Optional.ofNullable(
+                queryFactory
+                        .select(new QReviewInfoDto(
+                                review.id.as("_id"),
+                                room.id.as("roomId"),
+                                room.name.as("roomName"),
+                                member.id.as("memberId"),
+                                member.name.as("memberName"),
+                                booking.id.as("bookingID"),
+                                review.title,
+                                review.content,
+                                review.grade
+                        ))
+                        .from(review)
+                        .innerJoin(review.booking, booking)
+                        .innerJoin(booking.room, room)
+                        .innerJoin(booking.member, member)
+                        .where(booking.id.eq(bookingDto.getId()))
+                        .fetchOne()
+        );
     }
 
     @Override

--- a/src/main/java/dingulcamping/reservationapp/domain/review/service/ReviewService.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/service/ReviewService.java
@@ -1,0 +1,42 @@
+package dingulcamping.reservationapp.domain.review.service;
+
+import dingulcamping.reservationapp.domain.booking.entity.Booking;
+import dingulcamping.reservationapp.domain.booking.exception.NotExistBookingException;
+import dingulcamping.reservationapp.domain.booking.repository.BookingRepository;
+import dingulcamping.reservationapp.domain.member.entity.Member;
+import dingulcamping.reservationapp.domain.review.dto.ReviewCreateDto;
+import dingulcamping.reservationapp.domain.review.entity.Review;
+import dingulcamping.reservationapp.domain.review.exception.InvalidMemberException;
+import dingulcamping.reservationapp.domain.review.exception.ReviewIsExistException;
+import dingulcamping.reservationapp.domain.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final BookingRepository bookingRepository;
+
+    @Transactional
+    public void createReview(ReviewCreateDto reviewCreateDto, Member member) {
+        Booking booking =
+                bookingRepository.findById(reviewCreateDto.getBookingID()).orElseThrow(NotExistBookingException::new);
+        reviewRepository.findByBooking(booking).ifPresent(r -> {
+            throw new ReviewIsExistException();
+        });
+        if(member.getId()!=booking.getMember().getId()){
+            throw new InvalidMemberException();
+        }
+
+        Review review = new Review(reviewCreateDto, booking, member);
+        reviewRepository.save(review);
+    }
+}

--- a/src/main/java/dingulcamping/reservationapp/domain/review/service/ReviewService.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/service/ReviewService.java
@@ -53,4 +53,11 @@ public class ReviewService {
         Booking booking = bookingRepository.findById(bookingID).orElseThrow(NotExistBookingException::new);
         return reviewRepository.findByBooking(booking).orElseThrow(NotExistReviewException::new);
     }
+
+    @Transactional
+    public void updateReview(Long reviewID, ReviewUpdateDto reviewUpdateDto) {
+        Review review = reviewRepository.findById(reviewID).orElseThrow(NotExistReviewException::new);
+        review.updateReview(reviewUpdateDto);
+    }
+
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/review/service/ReviewService.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/service/ReviewService.java
@@ -5,16 +5,19 @@ import dingulcamping.reservationapp.domain.booking.exception.NotExistBookingExce
 import dingulcamping.reservationapp.domain.booking.repository.BookingRepository;
 import dingulcamping.reservationapp.domain.member.entity.Member;
 import dingulcamping.reservationapp.domain.review.dto.ReviewCreateDto;
+import dingulcamping.reservationapp.domain.review.dto.ReviewInfoDto;
 import dingulcamping.reservationapp.domain.review.entity.Review;
 import dingulcamping.reservationapp.domain.review.exception.InvalidMemberException;
 import dingulcamping.reservationapp.domain.review.exception.ReviewIsExistException;
 import dingulcamping.reservationapp.domain.review.repository.ReviewRepository;
+import dingulcamping.reservationapp.domain.room.entity.Room;
+import dingulcamping.reservationapp.domain.room.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +25,7 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 public class ReviewService {
 
+    private final RoomRepository roomRepository;
     private final ReviewRepository reviewRepository;
     private final BookingRepository bookingRepository;
 
@@ -38,5 +42,10 @@ public class ReviewService {
 
         Review review = new Review(reviewCreateDto, booking, member);
         reviewRepository.save(review);
+    }
+
+    public Page<ReviewInfoDto> getRoomReviews(Long roomID, Pageable pageable) {
+        Room room = roomRepository.findById(roomID).orElseThrow(NotExistBookingException::new);
+        return reviewRepository.findByRoom(room,pageable);
     }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/review/service/ReviewService.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/service/ReviewService.java
@@ -48,4 +48,9 @@ public class ReviewService {
         Room room = roomRepository.findById(roomID).orElseThrow(NotExistBookingException::new);
         return reviewRepository.findByRoom(room,pageable);
     }
+
+    public ReviewInfoDto getBookingReview(Long bookingID) {
+        Booking booking = bookingRepository.findById(bookingID).orElseThrow(NotExistBookingException::new);
+        return reviewRepository.findByBooking(booking).orElseThrow(NotExistReviewException::new);
+    }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/review/service/ReviewService.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/review/service/ReviewService.java
@@ -6,8 +6,10 @@ import dingulcamping.reservationapp.domain.booking.repository.BookingRepository;
 import dingulcamping.reservationapp.domain.member.entity.Member;
 import dingulcamping.reservationapp.domain.review.dto.ReviewCreateDto;
 import dingulcamping.reservationapp.domain.review.dto.ReviewInfoDto;
+import dingulcamping.reservationapp.domain.review.dto.ReviewUpdateDto;
 import dingulcamping.reservationapp.domain.review.entity.Review;
 import dingulcamping.reservationapp.domain.review.exception.InvalidMemberException;
+import dingulcamping.reservationapp.domain.review.exception.NotExistReviewException;
 import dingulcamping.reservationapp.domain.review.exception.ReviewIsExistException;
 import dingulcamping.reservationapp.domain.review.repository.ReviewRepository;
 import dingulcamping.reservationapp.domain.room.entity.Room;
@@ -60,4 +62,11 @@ public class ReviewService {
         review.updateReview(reviewUpdateDto);
     }
 
+    @Transactional
+    public void deleteReview(Long reviewID) {
+        Review review = reviewRepository.findById(reviewID).orElseThrow(NotExistReviewException::new);
+        Booking booking = review.getBooking();
+        reviewRepository.deleteById(reviewID);
+        booking.deleteReview();
+    }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/room/dto/RoomDetailDto.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/room/dto/RoomDetailDto.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Setter
 @AllArgsConstructor
 public class RoomDetailDto {
-    private Long id;
+    private Long _id;
     private String name;
     private int price;
     private String content;
@@ -29,7 +29,7 @@ public class RoomDetailDto {
     private MapPosition position;
 
     public RoomDetailDto(Room room){
-        this.id=room.getId();
+        this._id=room.getId();
         this.name=room.getName();
         this.price=room.getPrice();
         this.content=room.getContent();

--- a/src/main/java/dingulcamping/reservationapp/domain/room/dto/RoomInfoDto.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/room/dto/RoomInfoDto.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class RoomInfoDto {
-    private Long id;
+    private Long _id;
     private String name;
     private int price;
     private RoomType roomType;
@@ -20,7 +20,7 @@ public class RoomInfoDto {
 
     @QueryProjection
     public RoomInfoDto(Long id, String name, int price, RoomType roomType, String icon, int maxPeople, int minPeople, MapPosition position) {
-        this.id = id;
+        this._id = id;
         this.name = name;
         this.price = price;
         this.roomType = roomType;

--- a/src/main/java/dingulcamping/reservationapp/domain/room/entity/RoomType.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/room/entity/RoomType.java
@@ -3,10 +3,10 @@ package dingulcamping.reservationapp.domain.room.entity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 public enum RoomType {
-    CARAVAN, TENT, GLAMPING;
+    Caravan, Tent, Glamping;
 
     @JsonCreator
     public static RoomType from(String s) {
-        return RoomType.valueOf(s.toUpperCase());
+        return RoomType.valueOf(s);
     }
 }

--- a/src/main/java/dingulcamping/reservationapp/domain/room/repository/RoomRepositoryImpl.java
+++ b/src/main/java/dingulcamping/reservationapp/domain/room/repository/RoomRepositoryImpl.java
@@ -3,7 +3,6 @@ package dingulcamping.reservationapp.domain.room.repository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import dingulcamping.reservationapp.domain.room.dto.QSimpleRoomDto;
 import dingulcamping.reservationapp.domain.room.dto.SimpleRoomDto;
-import dingulcamping.reservationapp.domain.booking.dto.QBookingRoomDto;
 import dingulcamping.reservationapp.domain.room.dto.QRoomInfoDto;
 import dingulcamping.reservationapp.domain.room.dto.RoomInfoDto;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/dingulcamping/reservationapp/global/config/WebConfig.java
+++ b/src/main/java/dingulcamping/reservationapp/global/config/WebConfig.java
@@ -2,10 +2,7 @@ package dingulcamping.reservationapp.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
-import org.springframework.data.web.SortHandlerMethodArgumentResolver;
-import org.springframework.http.HttpMethod;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -22,6 +19,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowCredentials(true)
+                .allowedHeaders("*")
                 .allowedMethods("GET","POST","PATCH","DELETE")
                 .allowedOrigins(frontServer);
     }

--- a/src/main/java/dingulcamping/reservationapp/global/config/WebSecurityConfig.java
+++ b/src/main/java/dingulcamping/reservationapp/global/config/WebSecurityConfig.java
@@ -43,6 +43,7 @@ public class WebSecurityConfig{
                         .requestMatchers(HttpMethod.PATCH,"/api/password").permitAll()
                         .requestMatchers(HttpMethod.GET,"/api/room/**").permitAll()
                         .requestMatchers(HttpMethod.GET,"/api/room").permitAll()
+                        .requestMatchers(HttpMethod.GET,"/api/review").permitAll()
                         .requestMatchers(HttpMethod.POST,"/api/room/**").hasRole("ADMIN")
                         .requestMatchers("/api/admin/**").hasAnyAuthority("ADMIN","ROLE_ADMIN")
                         .requestMatchers("/api/**").authenticated()

--- a/src/main/java/dingulcamping/reservationapp/global/exception/ErrorCode.java
+++ b/src/main/java/dingulcamping/reservationapp/global/exception/ErrorCode.java
@@ -30,7 +30,8 @@ public enum ErrorCode {
 
     //REVIEW
     REVIEW_IS_EXIST(400,"이미 리뷰가 작성된 예약입니다."),
-    INVALID_MEMBER(400, "리뷰 작성 권한이 없습니다.");
+    INVALID_MEMBER(400, "리뷰 작성 권한이 없습니다."),
+    NOT_EXIST_REVIEW(404, "해당 리뷰를 찾을 수 없습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/dingulcamping/reservationapp/global/exception/ErrorCode.java
+++ b/src/main/java/dingulcamping/reservationapp/global/exception/ErrorCode.java
@@ -26,9 +26,11 @@ public enum ErrorCode {
     DISABLE_BOOKING_DATE(400,"해당 기간에 이미 예약이 존재합니다."),
     INVALID_PEOPLE_NUMBER(400,"정원이 맞지 않습니다."),
     INVALID_START_DATE(400,"날짜가 유효하지 않습니다."),
-    NOT_EXIST_BOOKING(404,"해당 예약을 찾을 수 없습니다.");
+    NOT_EXIST_BOOKING(404,"해당 예약을 찾을 수 없습니다."),
 
     //REVIEW
+    REVIEW_IS_EXIST(400,"이미 리뷰가 작성된 예약입니다."),
+    INVALID_MEMBER(400, "리뷰 작성 권한이 없습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/dingulcamping/reservationapp/global/exception/ErrorDto.java
+++ b/src/main/java/dingulcamping/reservationapp/global/exception/ErrorDto.java
@@ -9,5 +9,6 @@ import lombok.Setter;
 @AllArgsConstructor
 public class ErrorDto {
     private int status;
-    private String message;
+    private String reason;
+    private String result;
 }

--- a/src/main/java/dingulcamping/reservationapp/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dingulcamping/reservationapp/global/exception/GlobalExceptionHandler.java
@@ -13,15 +13,18 @@ import static dingulcamping.reservationapp.global.exception.ErrorCode.INTERNAL_S
 @Slf4j
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler({ CustomException.class })
+    @ExceptionHandler({CustomException.class})
     protected ResponseEntity handleCustomException(CustomException ex) {
-        return new ResponseEntity(new ErrorDto(ex.getErrorCode().getStatus(), ex.getErrorCode().getMessage()), HttpStatus.valueOf(ex.getErrorCode().getStatus()));
+        return new ResponseEntity(
+                new ErrorDto(ex.getErrorCode().getStatus(), ex.getErrorCode().getMessage(), "error"),
+                HttpStatus.valueOf(ex.getErrorCode().getStatus()));
     }
 
-    @ExceptionHandler({ Exception.class })
+    @ExceptionHandler({Exception.class})
     protected ResponseEntity handleServerException(Exception e) {
-        log.error("error Message = {}",e.getMessage());
-        return new ResponseEntity(new ErrorDto(INTERNAL_SERVER_ERROR.getStatus(),
-                INTERNAL_SERVER_ERROR.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
+        log.error("error Message = {}", e.getMessage());
+        return new ResponseEntity(
+                new ErrorDto(INTERNAL_SERVER_ERROR.getStatus(), INTERNAL_SERVER_ERROR.getMessage(), "error"),
+                HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/dingulcamping/reservationapp/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dingulcamping/reservationapp/global/exception/GlobalExceptionHandler.java
@@ -20,7 +20,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({ Exception.class })
     protected ResponseEntity handleServerException(Exception e) {
-        log.error(e.getMessage());
+        log.error("error Message = {}",e.getMessage());
         return new ResponseEntity(new ErrorDto(INTERNAL_SERVER_ERROR.getStatus(),
                 INTERNAL_SERVER_ERROR.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/src/main/java/dingulcamping/reservationapp/global/security/CookieManager.java
+++ b/src/main/java/dingulcamping/reservationapp/global/security/CookieManager.java
@@ -1,0 +1,31 @@
+package dingulcamping.reservationapp.global.security;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CookieManager {
+
+    public final static int ACCESS_EXP=30 * 60 * 1000;
+    public final static int REFRESH_EXP=1000 * 60 * 60 * 24 * 14;
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge,
+                                  Boolean httpsOnly) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static String getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/dingulcamping/reservationapp/global/security/JwtFilter.java
+++ b/src/main/java/dingulcamping/reservationapp/global/security/JwtFilter.java
@@ -20,6 +20,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.Arrays;
 
+import static dingulcamping.reservationapp.global.security.CookieManager.ACCESS_EXP;
+import static dingulcamping.reservationapp.global.security.CookieManager.getCookie;
+
 @RequiredArgsConstructor
 @Slf4j
 public class JwtFilter extends OncePerRequestFilter {
@@ -30,11 +33,10 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        final String authorization=request.getHeader(HttpHeaders.AUTHORIZATION);
+        String accessToken = getCookie(request, "accessToken");
+        log.info("accessToken : {}", accessToken);
 
-        log.info("authorization : {}", authorization);
-
-        if(authorization==null || !authorization.startsWith("Bearer ")){
+        if(accessToken==null){
             //인증이 안되었을때 block
             log.error("authorization is null");
             filterChain.doFilter(request,response);
@@ -44,14 +46,10 @@ public class JwtFilter extends OncePerRequestFilter {
         Long memberId=null;
         Role role=null;
 
-        //Token 꺼내기
-        String token=authorization.split(" ")[1];
-        log.info("token={}",token);
-        log.info("secretKey={}",secretKey);
-//        //Token Expired 되었는지 여부
-        if(JwtUtils.isExpired(token,secretKey)){
+        //Token Expired 되었는지 여부
+        if(JwtUtils.isExpired(accessToken,secretKey)){
             log.error("Access Token이 만료되었습니다");
-            String refreshToken = getRefreshToken(request);
+            String refreshToken = getCookie(request,"refreshToken");
             if(refreshToken==null){
                 filterChain.doFilter(request,response);
                 return;
@@ -65,9 +63,11 @@ public class JwtFilter extends OncePerRequestFilter {
             role=Role.valueOf(JwtUtils.getRole(refreshToken,secretKey));
             String newAccessToken = JwtUtils.createJwt(memberId, role, secretKey, 30 * 60 * 1000l);
             response.addHeader("authorization", "Bearer "+newAccessToken);
+            CookieManager.addCookie(response, "accessToken", newAccessToken, ACCESS_EXP,true);
+            CookieManager.addCookie(response, "userRole", role.toLowerCase(), ACCESS_EXP,false);
         }else{
-            memberId = JwtUtils.getMemberId(token, secretKey);
-            role=Role.valueOf(JwtUtils.getRole(token,secretKey));
+            memberId = JwtUtils.getMemberId(accessToken, secretKey);
+            role=Role.valueOf(JwtUtils.getRole(accessToken,secretKey));
         }
 
         UsernamePasswordAuthenticationToken authenticationToken=new UsernamePasswordAuthenticationToken(memberId,

--- a/src/main/java/dingulcamping/reservationapp/global/security/JwtUtils.java
+++ b/src/main/java/dingulcamping/reservationapp/global/security/JwtUtils.java
@@ -2,10 +2,7 @@ package dingulcamping.reservationapp.global.security;
 
 import dingulcamping.reservationapp.domain.member.entity.Role;
 import dingulcamping.reservationapp.domain.member.repository.RefreshTokenRepository;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -33,7 +30,7 @@ public class JwtUtils {
     public static boolean isExpired(String token, String secretKey){
        try {
            return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getExpiration().before(new Date());
-       }catch(ExpiredJwtException e){
+       }catch(ExpiredJwtException | SignatureException e){
            return true;
        }
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,7 @@ spring.config.import=application-security.properties
 jpa.properties.hibernate.auto_quote_keyword=true
 hibernate.globally_quoted_identifiers=true
 front.server.address=http://localhost:3000
+server.servlet.cookie.same-site=None
+server.servlet.cookie.secure=true
+server.servlet.cookie.path=/
+server.servlet.session.cookie.path=/


### PR DESCRIPTION
## 🔗 Linked Issues
resolves #21 Review API 구현
<BR>

## 🔑 Key Changes

- review 생성 API 구현
- review 수정 API 구현
- review 삭제 API 구현
- room 별 리뷰 조회 API 구현
- Booking Id로 리뷰 조회 API 구현

<br>

## 💬Comment
[**ISO 표준 Date Json을 java Date 객체로 파싱하는 법**](https://www.baeldung.com/spring-boot-formatting-json-dates)

하지만 필자는 double quote(%22)가 Json date에 포함되어 받기 때문에 getDate라는 파싱 method를 따로 만들어 사용 (SearchByDateDto)

**Cookie의 경로 잘 확인할 것**
/api가 아닌 /여야 front의 모든 path에서 cookie 확인 가능하다
cookie의 default path 가 /api 였고 path를 바꿔서 cookie를 발급하기 위해 CookieManager 생성함